### PR TITLE
Support HTTP 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EHRAuthentication"
 uuid = "45047142-e73a-4b31-ae20-3729a1bbef33"
 authors = ["Dilum Aluthge", "Pumas-AI, Inc.", "contributors"]
-version = "2.0.0"
+version = "2.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -9,7 +9,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
-HTTP = "0.9"
+HTTP = "0.9, 1"
 JSON3 = "1"
 julia = "1.6"
 


### PR DESCRIPTION
This PR adds support for HTTP 1. Or rather, it bumps the compat entry but requires someone familiar with HTTP to carefully check whether HTTP 1 is actually supported or something in the code base has to be checked. It seems that unfortunately there are no actual tests, so one must not rely on CI tests passing successfully.

This updated was missed by the CompatHelper action since it was disabled due to inactivity: https://github.com/JuliaHealth/EHRAuthentication.jl/actions/workflows/CompatHelper.yml